### PR TITLE
Updated "postgres-operator" Dependency (3.5.2) & PGO-OSB Version Number (1.2.3)

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -18,14 +18,6 @@
   revision = "de5bf2ad457846296e2031421a34e2568e304e35"
 
 [[projects]]
-  digest = "1:ecf78eacf406c42f07f66d6b79fda24d2b92dc711bfd0760d0c931678f9621fe"
-  name = "github.com/Sirupsen/logrus"
-  packages = ["."]
-  pruneopts = "NUT"
-  revision = "ad15b42461921f1fb3529b058c6786c6a45d5162"
-  version = "v1.1.1"
-
-[[projects]]
   branch = "master"
   digest = "1:707ebe952a8b3d00b343c01536c79c73771d100f63ec6babeaed5c79e2b8a8dd"
   name = "github.com/beorn7/perks"
@@ -34,7 +26,7 @@
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
-  digest = "1:916339df5e9cd79a01ac02d064005d40e4e934727877b35061acc3ba3a44f264"
+  digest = "1:4c55656d7655f726e1622184fe53cf7e70e08cba1d314b83d59f627f40490565"
   name = "github.com/crunchydata/postgres-operator"
   packages = [
     "apis/cr/v1",
@@ -45,8 +37,8 @@
     "util",
   ]
   pruneopts = "NUT"
-  revision = "62ec8adddfc892df984bb389e3f14886f1ebf2f6"
-  version = "3.5.1"
+  revision = "7e867ebf211b488def26dfaf10d7b2b5bbd6f5f6"
+  version = "3.5.2"
 
 [[projects]]
   branch = "master"
@@ -399,6 +391,14 @@
   version = "0.0.3"
 
 [[projects]]
+  digest = "1:bb9033d47c116ea3b981ff159bdef73df8351b0b9700da2066339b97211b1bf0"
+  name = "github.com/sirupsen/logrus"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "dae0fa8d5b0c810a8ab733fbd5510c7cae84eca4"
+  version = "v1.4.0"
+
+[[projects]]
   digest = "1:ed545897e7363038a3e467e8b24c12e7f540f6a114c08a7dca7746a3fe291358"
   name = "github.com/spf13/pflag"
   packages = ["."]
@@ -632,7 +632,6 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
-    "github.com/Sirupsen/logrus",
     "github.com/crunchydata/postgres-operator/apiservermsgs",
     "github.com/crunchydata/postgres-operator/pgo/api",
     "github.com/crunchydata/postgres-operator/util",
@@ -644,6 +643,7 @@
     "github.com/prometheus/client_golang/prometheus",
     "github.com/satori/go.uuid",
     "github.com/shawn-hurley/osb-broker-k8s-lib/middleware",
+    "github.com/sirupsen/logrus",
     "gopkg.in/yaml.v2",
     "k8s.io/api/core/v1",
     "k8s.io/apimachinery/pkg/apis/meta/v1",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -42,12 +42,12 @@
   version = "v1.2.0"
 
 [[constraint]]
-  name = "github.com/Sirupsen/logrus"
+  name = "github.com/sirupsen/logrus"
   version = "v1.0.5"
 
 [[constraint]]
   name = "github.com/crunchydata/postgres-operator"
-  version = "3.5.1"
+  version = "3.5.2"
 
 [[override]]
   name = "github.com/spf13/cobra"

--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 image::crunchy_logo.png[Crunchy Data Logo]
 
-Latest Release: v1.2.2, {docdate}
+Latest Release: v1.2.3, {docdate}
 
 == General
 
@@ -30,6 +30,7 @@ See the following:
 
 == Compatibility
 
+ * pgo-osb 1.2.3 works with Postgres Operator 3.5.2
  * pgo-osb 1.2.2 works with Postgres Operator 3.5.1
  * pgo-osb 1.2.1 works with Postgres Operator 3.5.0
  * pgo-osb 1.2.0 works with Postgres Operator 3.4.0

--- a/centos7/Dockerfile.pgo-osb.centos7
+++ b/centos7/Dockerfile.pgo-osb.centos7
@@ -1,8 +1,8 @@
 FROM centos:7
 
 LABEL Vendor="Crunchy Data Solutions" \
-        Version="1.2.2" \
-        Release="1.2.2" \
+        Version="1.2.3" \
+        Release="1.2.3" \
         summary="Crunchy Data pgo-osb open service broker " \
         description="Crunchy Data PostgreSQL Operator - pgo-osb "
 

--- a/config/pgoconfig.go
+++ b/config/pgoconfig.go
@@ -17,11 +17,12 @@ limitations under the License.
 
 import (
 	"errors"
-	log "github.com/Sirupsen/logrus"
-	crv1 "github.com/crunchydata/pgo-osb/apis/cr/v1"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"strconv"
+
+	crv1 "github.com/crunchydata/pgo-osb/apis/cr/v1"
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
 )
 
 type ClusterStruct struct {

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -38,7 +38,7 @@ spec:
         - --CO_APISERVER_URL
         - "https://postgres-operator:8443"
         - --CO_APISERVER_VERSION
-        - "3.5.1"
+        - "3.5.2"
         - --insecure
         - "true"
         - --logtostderr

--- a/vendor/github.com/Sirupsen/logrus/alt_exit.go
+++ b/vendor/github.com/Sirupsen/logrus/alt_exit.go
@@ -51,9 +51,9 @@ func Exit(code int) {
 	os.Exit(code)
 }
 
-// RegisterExitHandler adds a Logrus Exit handler, call logrus.Exit to invoke
-// all handlers. The handlers will also be invoked when any Fatal log entry is
-// made.
+// RegisterExitHandler appends a Logrus Exit handler to the list of handlers,
+// call logrus.Exit to invoke all handlers. The handlers will also be invoked when
+// any Fatal log entry is made.
 //
 // This method is useful when a caller wishes to use logrus to log a fatal
 // message but also needs to gracefully shutdown. An example usecase could be
@@ -61,4 +61,16 @@ func Exit(code int) {
 // closing.
 func RegisterExitHandler(handler func()) {
 	handlers = append(handlers, handler)
+}
+
+// DeferExitHandler prepends a Logrus Exit handler to the list of handlers,
+// call logrus.Exit to invoke all handlers. The handlers will also be invoked when
+// any Fatal log entry is made.
+//
+// This method is useful when a caller wishes to use logrus to log a fatal
+// message but also needs to gracefully shutdown. An example usecase could be
+// closing database connections, or sending a alert that the application is
+// closing.
+func DeferExitHandler(handler func()) {
+	handlers = append([]func(){handler}, handlers...)
 }

--- a/vendor/github.com/Sirupsen/logrus/entry.go
+++ b/vendor/github.com/Sirupsen/logrus/entry.go
@@ -2,14 +2,33 @@ package logrus
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"reflect"
+	"runtime"
+	"strings"
 	"sync"
 	"time"
 )
 
-var bufferPool *sync.Pool
+var (
+	bufferPool *sync.Pool
+
+	// qualified package name, cached at first use
+	logrusPackage string
+
+	// Positions in the call stack when tracing to report the calling method
+	minimumCallerDepth int
+
+	// Used for caller information initialisation
+	callerInitOnce sync.Once
+)
+
+const (
+	maximumCallerDepth int = 25
+	knownLogrusFrames  int = 4
+)
 
 func init() {
 	bufferPool = &sync.Pool{
@@ -17,15 +36,18 @@ func init() {
 			return new(bytes.Buffer)
 		},
 	}
+
+	// start at the bottom of the stack before the package-name cache is primed
+	minimumCallerDepth = 1
 }
 
 // Defines the key when adding errors using WithError.
 var ErrorKey = "error"
 
 // An entry is the final or intermediate Logrus logging entry. It contains all
-// the fields passed with WithField{,s}. It's finally logged when Debug, Info,
-// Warn, Error, Fatal or Panic is called on it. These objects can be reused and
-// passed around as much as you wish to avoid field duplication.
+// the fields passed with WithField{,s}. It's finally logged when Trace, Debug,
+// Info, Warn, Error, Fatal or Panic is called on it. These objects can be
+// reused and passed around as much as you wish to avoid field duplication.
 type Entry struct {
 	Logger *Logger
 
@@ -35,15 +57,21 @@ type Entry struct {
 	// Time at which the log entry was created
 	Time time.Time
 
-	// Level the log entry was logged at: Debug, Info, Warn, Error, Fatal or Panic
+	// Level the log entry was logged at: Trace, Debug, Info, Warn, Error, Fatal or Panic
 	// This field will be set on entry firing and the value will be equal to the one in Logger struct field.
 	Level Level
 
-	// Message passed to Debug, Info, Warn, Error, Fatal or Panic
+	// Calling method, with package name
+	Caller *runtime.Frame
+
+	// Message passed to Trace, Debug, Info, Warn, Error, Fatal or Panic
 	Message string
 
 	// When formatter is called in entry.log(), a Buffer may be set to entry
 	Buffer *bytes.Buffer
+
+	// Contains the context set by the user. Useful for hook processing etc.
+	Context context.Context
 
 	// err may contain a field formatting error
 	err string
@@ -52,8 +80,8 @@ type Entry struct {
 func NewEntry(logger *Logger) *Entry {
 	return &Entry{
 		Logger: logger,
-		// Default is five fields, give a little extra room
-		Data: make(Fields, 5),
+		// Default is three fields, plus one optional.  Give a little extra room.
+		Data: make(Fields, 6),
 	}
 }
 
@@ -73,6 +101,12 @@ func (entry *Entry) WithError(err error) *Entry {
 	return entry.WithField(ErrorKey, err)
 }
 
+// Add a context to the Entry.
+func (entry *Entry) WithContext(ctx context.Context) *Entry {
+	entry.Context = ctx
+	return entry
+}
+
 // Add a single field to the Entry.
 func (entry *Entry) WithField(key string, value interface{}) *Entry {
 	return entry.WithFields(Fields{key: value})
@@ -84,23 +118,88 @@ func (entry *Entry) WithFields(fields Fields) *Entry {
 	for k, v := range entry.Data {
 		data[k] = v
 	}
-	var field_err string
+	fieldErr := entry.err
 	for k, v := range fields {
-		if t := reflect.TypeOf(v); t != nil && t.Kind() == reflect.Func {
-			field_err = fmt.Sprintf("can not add field %q", k)
-			if entry.err != "" {
-				field_err = entry.err + ", " + field_err
+		isErrField := false
+		if t := reflect.TypeOf(v); t != nil {
+			switch t.Kind() {
+			case reflect.Func:
+				isErrField = true
+			case reflect.Ptr:
+				isErrField = t.Elem().Kind() == reflect.Func
+			}
+		}
+		if isErrField {
+			tmp := fmt.Sprintf("can not add field %q", k)
+			if fieldErr != "" {
+				fieldErr = entry.err + ", " + tmp
+			} else {
+				fieldErr = tmp
 			}
 		} else {
 			data[k] = v
 		}
 	}
-	return &Entry{Logger: entry.Logger, Data: data, Time: entry.Time, err: field_err}
+	return &Entry{Logger: entry.Logger, Data: data, Time: entry.Time, err: fieldErr, Context: entry.Context}
 }
 
 // Overrides the time of the Entry.
 func (entry *Entry) WithTime(t time.Time) *Entry {
-	return &Entry{Logger: entry.Logger, Data: entry.Data, Time: t}
+	return &Entry{Logger: entry.Logger, Data: entry.Data, Time: t, err: entry.err, Context: entry.Context}
+}
+
+// getPackageName reduces a fully qualified function name to the package name
+// There really ought to be to be a better way...
+func getPackageName(f string) string {
+	for {
+		lastPeriod := strings.LastIndex(f, ".")
+		lastSlash := strings.LastIndex(f, "/")
+		if lastPeriod > lastSlash {
+			f = f[:lastPeriod]
+		} else {
+			break
+		}
+	}
+
+	return f
+}
+
+// getCaller retrieves the name of the first non-logrus calling function
+func getCaller() *runtime.Frame {
+
+	// cache this package's fully-qualified name
+	callerInitOnce.Do(func() {
+		pcs := make([]uintptr, 2)
+		_ = runtime.Callers(0, pcs)
+		logrusPackage = getPackageName(runtime.FuncForPC(pcs[1]).Name())
+
+		// now that we have the cache, we can skip a minimum count of known-logrus functions
+		// XXX this is dubious, the number of frames may vary
+		minimumCallerDepth = knownLogrusFrames
+	})
+
+	// Restrict the lookback frames to avoid runaway lookups
+	pcs := make([]uintptr, maximumCallerDepth)
+	depth := runtime.Callers(minimumCallerDepth, pcs)
+	frames := runtime.CallersFrames(pcs[:depth])
+
+	for f, again := frames.Next(); again; f, again = frames.Next() {
+		pkg := getPackageName(f.Function)
+
+		// If the caller isn't part of this package, we're done
+		if pkg != logrusPackage {
+			return &f
+		}
+	}
+
+	// if we got here, we failed to find the caller's context
+	return nil
+}
+
+func (entry Entry) HasCaller() (has bool) {
+	return entry.Logger != nil &&
+		entry.Logger.ReportCaller &&
+		entry.Caller != nil
 }
 
 // This function is not declared with a pointer value because otherwise
@@ -119,6 +218,9 @@ func (entry Entry) log(level Level, msg string) {
 
 	entry.Level = level
 	entry.Message = msg
+	if entry.Logger.ReportCaller {
+		entry.Caller = getCaller()
+	}
 
 	entry.fireHooks()
 
@@ -162,10 +264,18 @@ func (entry *Entry) write() {
 	}
 }
 
-func (entry *Entry) Debug(args ...interface{}) {
-	if entry.Logger.IsLevelEnabled(DebugLevel) {
-		entry.log(DebugLevel, fmt.Sprint(args...))
+func (entry *Entry) Log(level Level, args ...interface{}) {
+	if entry.Logger.IsLevelEnabled(level) {
+		entry.log(level, fmt.Sprint(args...))
 	}
+}
+
+func (entry *Entry) Trace(args ...interface{}) {
+	entry.Log(TraceLevel, args...)
+}
+
+func (entry *Entry) Debug(args ...interface{}) {
+	entry.Log(DebugLevel, args...)
 }
 
 func (entry *Entry) Print(args ...interface{}) {
@@ -173,15 +283,11 @@ func (entry *Entry) Print(args ...interface{}) {
 }
 
 func (entry *Entry) Info(args ...interface{}) {
-	if entry.Logger.IsLevelEnabled(InfoLevel) {
-		entry.log(InfoLevel, fmt.Sprint(args...))
-	}
+	entry.Log(InfoLevel, args...)
 }
 
 func (entry *Entry) Warn(args ...interface{}) {
-	if entry.Logger.IsLevelEnabled(WarnLevel) {
-		entry.log(WarnLevel, fmt.Sprint(args...))
-	}
+	entry.Log(WarnLevel, args...)
 }
 
 func (entry *Entry) Warning(args ...interface{}) {
@@ -189,37 +295,37 @@ func (entry *Entry) Warning(args ...interface{}) {
 }
 
 func (entry *Entry) Error(args ...interface{}) {
-	if entry.Logger.IsLevelEnabled(ErrorLevel) {
-		entry.log(ErrorLevel, fmt.Sprint(args...))
-	}
+	entry.Log(ErrorLevel, args...)
 }
 
 func (entry *Entry) Fatal(args ...interface{}) {
-	if entry.Logger.IsLevelEnabled(FatalLevel) {
-		entry.log(FatalLevel, fmt.Sprint(args...))
-	}
-	Exit(1)
+	entry.Log(FatalLevel, args...)
+	entry.Logger.Exit(1)
 }
 
 func (entry *Entry) Panic(args ...interface{}) {
-	if entry.Logger.IsLevelEnabled(PanicLevel) {
-		entry.log(PanicLevel, fmt.Sprint(args...))
-	}
+	entry.Log(PanicLevel, args...)
 	panic(fmt.Sprint(args...))
 }
 
 // Entry Printf family functions
 
-func (entry *Entry) Debugf(format string, args ...interface{}) {
-	if entry.Logger.IsLevelEnabled(DebugLevel) {
-		entry.Debug(fmt.Sprintf(format, args...))
+func (entry *Entry) Logf(level Level, format string, args ...interface{}) {
+	if entry.Logger.IsLevelEnabled(level) {
+		entry.Log(level, fmt.Sprintf(format, args...))
 	}
 }
 
+func (entry *Entry) Tracef(format string, args ...interface{}) {
+	entry.Logf(TraceLevel, format, args...)
+}
+
+func (entry *Entry) Debugf(format string, args ...interface{}) {
+	entry.Logf(DebugLevel, format, args...)
+}
+
 func (entry *Entry) Infof(format string, args ...interface{}) {
-	if entry.Logger.IsLevelEnabled(InfoLevel) {
-		entry.Info(fmt.Sprintf(format, args...))
-	}
+	entry.Logf(InfoLevel, format, args...)
 }
 
 func (entry *Entry) Printf(format string, args ...interface{}) {
@@ -227,9 +333,7 @@ func (entry *Entry) Printf(format string, args ...interface{}) {
 }
 
 func (entry *Entry) Warnf(format string, args ...interface{}) {
-	if entry.Logger.IsLevelEnabled(WarnLevel) {
-		entry.Warn(fmt.Sprintf(format, args...))
-	}
+	entry.Logf(WarnLevel, format, args...)
 }
 
 func (entry *Entry) Warningf(format string, args ...interface{}) {
@@ -237,36 +341,36 @@ func (entry *Entry) Warningf(format string, args ...interface{}) {
 }
 
 func (entry *Entry) Errorf(format string, args ...interface{}) {
-	if entry.Logger.IsLevelEnabled(ErrorLevel) {
-		entry.Error(fmt.Sprintf(format, args...))
-	}
+	entry.Logf(ErrorLevel, format, args...)
 }
 
 func (entry *Entry) Fatalf(format string, args ...interface{}) {
-	if entry.Logger.IsLevelEnabled(FatalLevel) {
-		entry.Fatal(fmt.Sprintf(format, args...))
-	}
-	Exit(1)
+	entry.Logf(FatalLevel, format, args...)
+	entry.Logger.Exit(1)
 }
 
 func (entry *Entry) Panicf(format string, args ...interface{}) {
-	if entry.Logger.IsLevelEnabled(PanicLevel) {
-		entry.Panic(fmt.Sprintf(format, args...))
-	}
+	entry.Logf(PanicLevel, format, args...)
 }
 
 // Entry Println family functions
 
-func (entry *Entry) Debugln(args ...interface{}) {
-	if entry.Logger.IsLevelEnabled(DebugLevel) {
-		entry.Debug(entry.sprintlnn(args...))
+func (entry *Entry) Logln(level Level, args ...interface{}) {
+	if entry.Logger.IsLevelEnabled(level) {
+		entry.Log(level, entry.sprintlnn(args...))
 	}
 }
 
+func (entry *Entry) Traceln(args ...interface{}) {
+	entry.Logln(TraceLevel, args...)
+}
+
+func (entry *Entry) Debugln(args ...interface{}) {
+	entry.Logln(DebugLevel, args...)
+}
+
 func (entry *Entry) Infoln(args ...interface{}) {
-	if entry.Logger.IsLevelEnabled(InfoLevel) {
-		entry.Info(entry.sprintlnn(args...))
-	}
+	entry.Logln(InfoLevel, args...)
 }
 
 func (entry *Entry) Println(args ...interface{}) {
@@ -274,9 +378,7 @@ func (entry *Entry) Println(args ...interface{}) {
 }
 
 func (entry *Entry) Warnln(args ...interface{}) {
-	if entry.Logger.IsLevelEnabled(WarnLevel) {
-		entry.Warn(entry.sprintlnn(args...))
-	}
+	entry.Logln(WarnLevel, args...)
 }
 
 func (entry *Entry) Warningln(args ...interface{}) {
@@ -284,22 +386,16 @@ func (entry *Entry) Warningln(args ...interface{}) {
 }
 
 func (entry *Entry) Errorln(args ...interface{}) {
-	if entry.Logger.IsLevelEnabled(ErrorLevel) {
-		entry.Error(entry.sprintlnn(args...))
-	}
+	entry.Logln(ErrorLevel, args...)
 }
 
 func (entry *Entry) Fatalln(args ...interface{}) {
-	if entry.Logger.IsLevelEnabled(FatalLevel) {
-		entry.Fatal(entry.sprintlnn(args...))
-	}
-	Exit(1)
+	entry.Logln(FatalLevel, args...)
+	entry.Logger.Exit(1)
 }
 
 func (entry *Entry) Panicln(args ...interface{}) {
-	if entry.Logger.IsLevelEnabled(PanicLevel) {
-		entry.Panic(entry.sprintlnn(args...))
-	}
+	entry.Logln(PanicLevel, args...)
 }
 
 // Sprintlnn => Sprint no newline. This is to get the behavior of how

--- a/vendor/github.com/Sirupsen/logrus/exported.go
+++ b/vendor/github.com/Sirupsen/logrus/exported.go
@@ -1,6 +1,7 @@
 package logrus
 
 import (
+	"context"
 	"io"
 	"time"
 )
@@ -22,6 +23,12 @@ func SetOutput(out io.Writer) {
 // SetFormatter sets the standard logger formatter.
 func SetFormatter(formatter Formatter) {
 	std.SetFormatter(formatter)
+}
+
+// SetReportCaller sets whether the standard logger will include the calling
+// method as a field.
+func SetReportCaller(include bool) {
+	std.SetReportCaller(include)
 }
 
 // SetLevel sets the standard logger level.
@@ -47,6 +54,11 @@ func AddHook(hook Hook) {
 // WithError creates an entry from the standard logger and adds an error to it, using the value defined in ErrorKey as key.
 func WithError(err error) *Entry {
 	return std.WithField(ErrorKey, err)
+}
+
+// WithContext creates an entry from the standard logger and adds a context to it.
+func WithContext(ctx context.Context) *Entry {
+	return std.WithContext(ctx)
 }
 
 // WithField creates an entry from the standard logger and adds a field to
@@ -75,6 +87,11 @@ func WithFields(fields Fields) *Entry {
 // or Panic on the Entry it returns.
 func WithTime(t time.Time) *Entry {
 	return std.WithTime(t)
+}
+
+// Trace logs a message at level Trace on the standard logger.
+func Trace(args ...interface{}) {
+	std.Trace(args...)
 }
 
 // Debug logs a message at level Debug on the standard logger.
@@ -117,6 +134,11 @@ func Fatal(args ...interface{}) {
 	std.Fatal(args...)
 }
 
+// Tracef logs a message at level Trace on the standard logger.
+func Tracef(format string, args ...interface{}) {
+	std.Tracef(format, args...)
+}
+
 // Debugf logs a message at level Debug on the standard logger.
 func Debugf(format string, args ...interface{}) {
 	std.Debugf(format, args...)
@@ -155,6 +177,11 @@ func Panicf(format string, args ...interface{}) {
 // Fatalf logs a message at level Fatal on the standard logger then the process will exit with status set to 1.
 func Fatalf(format string, args ...interface{}) {
 	std.Fatalf(format, args...)
+}
+
+// Traceln logs a message at level Trace on the standard logger.
+func Traceln(args ...interface{}) {
+	std.Traceln(args...)
 }
 
 // Debugln logs a message at level Debug on the standard logger.

--- a/vendor/github.com/Sirupsen/logrus/formatter.go
+++ b/vendor/github.com/Sirupsen/logrus/formatter.go
@@ -9,6 +9,8 @@ const (
 	FieldKeyLevel          = "level"
 	FieldKeyTime           = "time"
 	FieldKeyLogrusError    = "logrus_error"
+	FieldKeyFunc           = "func"
+	FieldKeyFile           = "file"
 )
 
 // The Formatter interface is used to implement a custom Formatter. It takes an
@@ -25,7 +27,7 @@ type Formatter interface {
 	Format(*Entry) ([]byte, error)
 }
 
-// This is to not silently overwrite `time`, `msg` and `level` fields when
+// This is to not silently overwrite `time`, `msg`, `func` and `level` fields when
 // dumping it. If this code wasn't there doing:
 //
 //  logrus.WithField("level", 1).Info("hello")
@@ -37,7 +39,7 @@ type Formatter interface {
 //
 // It's not exported because it's still using Data in an opinionated way. It's to
 // avoid code duplication between the two default formatters.
-func prefixFieldClashes(data Fields, fieldMap FieldMap) {
+func prefixFieldClashes(data Fields, fieldMap FieldMap, reportCaller bool) {
 	timeKey := fieldMap.resolve(FieldKeyTime)
 	if t, ok := data[timeKey]; ok {
 		data["fields."+timeKey] = t
@@ -60,5 +62,17 @@ func prefixFieldClashes(data Fields, fieldMap FieldMap) {
 	if l, ok := data[logrusErrKey]; ok {
 		data["fields."+logrusErrKey] = l
 		delete(data, logrusErrKey)
+	}
+
+	// If reportCaller is not set, 'func' will not conflict.
+	if reportCaller {
+		funcKey := fieldMap.resolve(FieldKeyFunc)
+		if l, ok := data[funcKey]; ok {
+			data["fields."+funcKey] = l
+		}
+		fileKey := fieldMap.resolve(FieldKeyFile)
+		if l, ok := data[fileKey]; ok {
+			data["fields."+fileKey] = l
+		}
 	}
 }

--- a/vendor/github.com/Sirupsen/logrus/json_formatter.go
+++ b/vendor/github.com/Sirupsen/logrus/json_formatter.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"runtime"
 )
 
 type fieldKey string
@@ -34,12 +35,19 @@ type JSONFormatter struct {
 	// As an example:
 	// formatter := &JSONFormatter{
 	//   	FieldMap: FieldMap{
-	// 		 FieldKeyTime: "@timestamp",
+	// 		 FieldKeyTime:  "@timestamp",
 	// 		 FieldKeyLevel: "@level",
-	// 		 FieldKeyMsg: "@message",
+	// 		 FieldKeyMsg:   "@message",
+	// 		 FieldKeyFunc:  "@caller",
 	//    },
 	// }
 	FieldMap FieldMap
+
+	// CallerPrettyfier can be set by the user to modify the content
+	// of the function and file keys in the json data when ReportCaller is
+	// activated. If any of the returned value is the empty string the
+	// corresponding key will be removed from json fields.
+	CallerPrettyfier func(*runtime.Frame) (function string, file string)
 
 	// PrettyPrint will indent all json logs
 	PrettyPrint bool
@@ -47,7 +55,7 @@ type JSONFormatter struct {
 
 // Format renders a single log entry
 func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
-	data := make(Fields, len(entry.Data)+3)
+	data := make(Fields, len(entry.Data)+4)
 	for k, v := range entry.Data {
 		switch v := v.(type) {
 		case error:
@@ -65,7 +73,7 @@ func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
 		data = newData
 	}
 
-	prefixFieldClashes(data, f.FieldMap)
+	prefixFieldClashes(data, f.FieldMap, entry.HasCaller())
 
 	timestampFormat := f.TimestampFormat
 	if timestampFormat == "" {
@@ -80,6 +88,19 @@ func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
 	}
 	data[f.FieldMap.resolve(FieldKeyMsg)] = entry.Message
 	data[f.FieldMap.resolve(FieldKeyLevel)] = entry.Level.String()
+	if entry.HasCaller() {
+		funcVal := entry.Caller.Function
+		fileVal := fmt.Sprintf("%s:%d", entry.Caller.File, entry.Caller.Line)
+		if f.CallerPrettyfier != nil {
+			funcVal, fileVal = f.CallerPrettyfier(entry.Caller)
+		}
+		if funcVal != "" {
+			data[f.FieldMap.resolve(FieldKeyFunc)] = funcVal
+		}
+		if fileVal != "" {
+			data[f.FieldMap.resolve(FieldKeyFile)] = fileVal
+		}
+	}
 
 	var b *bytes.Buffer
 	if entry.Buffer != nil {
@@ -93,7 +114,7 @@ func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
 		encoder.SetIndent("", "  ")
 	}
 	if err := encoder.Encode(data); err != nil {
-		return nil, fmt.Errorf("Failed to marshal fields to JSON, %v", err)
+		return nil, fmt.Errorf("failed to marshal fields to JSON, %v", err)
 	}
 
 	return b.Bytes(), nil

--- a/vendor/github.com/Sirupsen/logrus/logrus.go
+++ b/vendor/github.com/Sirupsen/logrus/logrus.go
@@ -14,22 +14,11 @@ type Level uint32
 
 // Convert the Level to a string. E.g. PanicLevel becomes "panic".
 func (level Level) String() string {
-	switch level {
-	case DebugLevel:
-		return "debug"
-	case InfoLevel:
-		return "info"
-	case WarnLevel:
-		return "warning"
-	case ErrorLevel:
-		return "error"
-	case FatalLevel:
-		return "fatal"
-	case PanicLevel:
-		return "panic"
+	if b, err := level.MarshalText(); err == nil {
+		return string(b)
+	} else {
+		return "unknown"
 	}
-
-	return "unknown"
 }
 
 // ParseLevel takes a string level and returns the Logrus log level constant.
@@ -47,10 +36,45 @@ func ParseLevel(lvl string) (Level, error) {
 		return InfoLevel, nil
 	case "debug":
 		return DebugLevel, nil
+	case "trace":
+		return TraceLevel, nil
 	}
 
 	var l Level
 	return l, fmt.Errorf("not a valid logrus Level: %q", lvl)
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (level *Level) UnmarshalText(text []byte) error {
+	l, err := ParseLevel(string(text))
+	if err != nil {
+		return err
+	}
+
+	*level = Level(l)
+
+	return nil
+}
+
+func (level Level) MarshalText() ([]byte, error) {
+	switch level {
+	case TraceLevel:
+		return []byte("trace"), nil
+	case DebugLevel:
+		return []byte("debug"), nil
+	case InfoLevel:
+		return []byte("info"), nil
+	case WarnLevel:
+		return []byte("warning"), nil
+	case ErrorLevel:
+		return []byte("error"), nil
+	case FatalLevel:
+		return []byte("fatal"), nil
+	case PanicLevel:
+		return []byte("panic"), nil
+	}
+
+	return nil, fmt.Errorf("not a valid logrus level %d", level)
 }
 
 // A constant exposing all logging levels
@@ -61,6 +85,7 @@ var AllLevels = []Level{
 	WarnLevel,
 	InfoLevel,
 	DebugLevel,
+	TraceLevel,
 }
 
 // These are the different logging levels. You can set the logging level to log
@@ -69,7 +94,7 @@ const (
 	// PanicLevel level, highest level of severity. Logs and then calls panic with the
 	// message passed to Debug, Info, ...
 	PanicLevel Level = iota
-	// FatalLevel level. Logs and then calls `os.Exit(1)`. It will exit even if the
+	// FatalLevel level. Logs and then calls `logger.Exit(1)`. It will exit even if the
 	// logging level is set to Panic.
 	FatalLevel
 	// ErrorLevel level. Logs. Used for errors that should definitely be noted.
@@ -82,6 +107,8 @@ const (
 	InfoLevel
 	// DebugLevel level. Usually only enabled when debugging. Very verbose logging.
 	DebugLevel
+	// TraceLevel level. Designates finer-grained informational events than the Debug.
+	TraceLevel
 )
 
 // Won't compile if StdLogger can't be realized by a log.Logger
@@ -147,4 +174,13 @@ type FieldLogger interface {
 	// IsErrorEnabled() bool
 	// IsFatalEnabled() bool
 	// IsPanicEnabled() bool
+}
+
+// Ext1FieldLogger (the first extension to FieldLogger) is superfluous, it is
+// here for consistancy. Do not use. Use Logger or Entry instead.
+type Ext1FieldLogger interface {
+	FieldLogger
+	Tracef(format string, args ...interface{})
+	Trace(args ...interface{})
+	Traceln(args ...interface{})
 }

--- a/vendor/github.com/Sirupsen/logrus/terminal_check_aix.go
+++ b/vendor/github.com/Sirupsen/logrus/terminal_check_aix.go
@@ -1,0 +1,9 @@
+// +build !appengine,!js,!windows,aix
+
+package logrus
+
+import "io"
+
+func checkIfTerminal(w io.Writer) bool {
+	return false
+}

--- a/vendor/github.com/Sirupsen/logrus/terminal_check_notappengine.go
+++ b/vendor/github.com/Sirupsen/logrus/terminal_check_notappengine.go
@@ -1,4 +1,4 @@
-// +build !appengine,!js,!windows
+// +build !appengine,!js,!windows,!aix
 
 package logrus
 

--- a/vendor/github.com/Sirupsen/logrus/text_formatter.go
+++ b/vendor/github.com/Sirupsen/logrus/text_formatter.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -11,18 +12,13 @@ import (
 )
 
 const (
-	nocolor = 0
-	red     = 31
-	green   = 32
-	yellow  = 33
-	blue    = 36
-	gray    = 37
+	red    = 31
+	yellow = 33
+	blue   = 36
+	gray   = 37
 )
 
-var (
-	baseTimestamp time.Time
-	emptyFieldMap FieldMap
-)
+var baseTimestamp time.Time
 
 func init() {
 	baseTimestamp = time.Now()
@@ -76,6 +72,12 @@ type TextFormatter struct {
 	//         FieldKeyMsg:   "@message"}}
 	FieldMap FieldMap
 
+	// CallerPrettyfier can be set by the user to modify the content
+	// of the function and file keys in the json data when ReportCaller is
+	// activated. If any of the returned value is the empty string the
+	// corresponding key will be removed from json fields.
+	CallerPrettyfier func(*runtime.Frame) (function string, file string)
+
 	terminalInitOnce sync.Once
 }
 
@@ -90,7 +92,7 @@ func (f *TextFormatter) init(entry *Entry) {
 }
 
 func (f *TextFormatter) isColored() bool {
-	isColored := f.ForceColors || f.isTerminal
+	isColored := f.ForceColors || (f.isTerminal && (runtime.GOOS != "windows"))
 
 	if f.EnvironmentOverrideColors {
 		if force, ok := os.LookupEnv("CLICOLOR_FORCE"); ok && force != "0" {
@@ -107,14 +109,19 @@ func (f *TextFormatter) isColored() bool {
 
 // Format renders a single log entry
 func (f *TextFormatter) Format(entry *Entry) ([]byte, error) {
-	prefixFieldClashes(entry.Data, f.FieldMap)
-
-	keys := make([]string, 0, len(entry.Data))
-	for k := range entry.Data {
+	data := make(Fields)
+	for k, v := range entry.Data {
+		data[k] = v
+	}
+	prefixFieldClashes(data, f.FieldMap, entry.HasCaller())
+	keys := make([]string, 0, len(data))
+	for k := range data {
 		keys = append(keys, k)
 	}
 
-	fixedKeys := make([]string, 0, 4+len(entry.Data))
+	var funcVal, fileVal string
+
+	fixedKeys := make([]string, 0, 4+len(data))
 	if !f.DisableTimestamp {
 		fixedKeys = append(fixedKeys, f.FieldMap.resolve(FieldKeyTime))
 	}
@@ -124,6 +131,16 @@ func (f *TextFormatter) Format(entry *Entry) ([]byte, error) {
 	}
 	if entry.err != "" {
 		fixedKeys = append(fixedKeys, f.FieldMap.resolve(FieldKeyLogrusError))
+	}
+	if entry.HasCaller() {
+		fixedKeys = append(fixedKeys,
+			f.FieldMap.resolve(FieldKeyFunc), f.FieldMap.resolve(FieldKeyFile))
+		if f.CallerPrettyfier != nil {
+			funcVal, fileVal = f.CallerPrettyfier(entry.Caller)
+		} else {
+			funcVal = entry.Caller.Function
+			fileVal = fmt.Sprintf("%s:%d", entry.Caller.File, entry.Caller.Line)
+		}
 	}
 
 	if !f.DisableSorting {
@@ -156,21 +173,26 @@ func (f *TextFormatter) Format(entry *Entry) ([]byte, error) {
 		timestampFormat = defaultTimestampFormat
 	}
 	if f.isColored() {
-		f.printColored(b, entry, keys, timestampFormat)
+		f.printColored(b, entry, keys, data, timestampFormat)
 	} else {
+
 		for _, key := range fixedKeys {
 			var value interface{}
-			switch key {
-			case f.FieldMap.resolve(FieldKeyTime):
+			switch {
+			case key == f.FieldMap.resolve(FieldKeyTime):
 				value = entry.Time.Format(timestampFormat)
-			case f.FieldMap.resolve(FieldKeyLevel):
+			case key == f.FieldMap.resolve(FieldKeyLevel):
 				value = entry.Level.String()
-			case f.FieldMap.resolve(FieldKeyMsg):
+			case key == f.FieldMap.resolve(FieldKeyMsg):
 				value = entry.Message
-			case f.FieldMap.resolve(FieldKeyLogrusError):
+			case key == f.FieldMap.resolve(FieldKeyLogrusError):
 				value = entry.err
+			case key == f.FieldMap.resolve(FieldKeyFunc) && entry.HasCaller():
+				value = funcVal
+			case key == f.FieldMap.resolve(FieldKeyFile) && entry.HasCaller():
+				value = fileVal
 			default:
-				value = entry.Data[key]
+				value = data[key]
 			}
 			f.appendKeyValue(b, key, value)
 		}
@@ -180,10 +202,10 @@ func (f *TextFormatter) Format(entry *Entry) ([]byte, error) {
 	return b.Bytes(), nil
 }
 
-func (f *TextFormatter) printColored(b *bytes.Buffer, entry *Entry, keys []string, timestampFormat string) {
+func (f *TextFormatter) printColored(b *bytes.Buffer, entry *Entry, keys []string, data Fields, timestampFormat string) {
 	var levelColor int
 	switch entry.Level {
-	case DebugLevel:
+	case DebugLevel, TraceLevel:
 		levelColor = gray
 	case WarnLevel:
 		levelColor = yellow
@@ -202,15 +224,27 @@ func (f *TextFormatter) printColored(b *bytes.Buffer, entry *Entry, keys []strin
 	// the behavior of logrus text_formatter the same as the stdlib log package
 	entry.Message = strings.TrimSuffix(entry.Message, "\n")
 
+	caller := ""
+
+	if entry.HasCaller() {
+		funcVal := fmt.Sprintf("%s()", entry.Caller.Function)
+		fileVal := fmt.Sprintf("%s:%d", entry.Caller.File, entry.Caller.Line)
+
+		if f.CallerPrettyfier != nil {
+			funcVal, fileVal = f.CallerPrettyfier(entry.Caller)
+		}
+		caller = fileVal + " " + funcVal
+	}
+
 	if f.DisableTimestamp {
-		fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m %-44s ", levelColor, levelText, entry.Message)
+		fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m%s %-44s ", levelColor, levelText, caller, entry.Message)
 	} else if !f.FullTimestamp {
-		fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m[%04d] %-44s ", levelColor, levelText, int(entry.Time.Sub(baseTimestamp)/time.Second), entry.Message)
+		fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m[%04d]%s %-44s ", levelColor, levelText, int(entry.Time.Sub(baseTimestamp)/time.Second), caller, entry.Message)
 	} else {
-		fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m[%s] %-44s ", levelColor, levelText, entry.Time.Format(timestampFormat), entry.Message)
+		fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m[%s]%s %-44s ", levelColor, levelText, entry.Time.Format(timestampFormat), caller, entry.Message)
 	}
 	for _, k := range keys {
-		v := entry.Data[k]
+		v := data[k]
 		fmt.Fprintf(b, " \x1b[%dm%s\x1b[0m=", levelColor, k)
 		f.appendValue(b, v)
 	}

--- a/vendor/github.com/Sirupsen/logrus/writer.go
+++ b/vendor/github.com/Sirupsen/logrus/writer.go
@@ -24,6 +24,8 @@ func (entry *Entry) WriterLevel(level Level) *io.PipeWriter {
 	var printFunc func(args ...interface{})
 
 	switch level {
+	case TraceLevel:
+		printFunc = entry.Trace
 	case DebugLevel:
 		printFunc = entry.Debug
 	case InfoLevel:

--- a/vendor/github.com/crunchydata/postgres-operator/LICENSE.md
+++ b/vendor/github.com/crunchydata/postgres-operator/LICENSE.md
@@ -176,7 +176,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2017 - 2018 Crunchy Data Solutions, Inc.
+   Copyright 2017 - 2019 Crunchy Data Solutions, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vendor/github.com/crunchydata/postgres-operator/apis/cr/v1/task.go
+++ b/vendor/github.com/crunchydata/postgres-operator/apis/cr/v1/task.go
@@ -36,6 +36,7 @@ const PgtaskAddPolicies = "addpolicies"
 
 const PgtaskWorkflow = "workflow"
 const PgtaskWorkflowCreateClusterType = "createcluster"
+const PgtaskWorkflowCreateBenchmarkType = "createbenchmark"
 const PgtaskWorkflowBackrestRestoreType = "pgbackrestrestore"
 const PgtaskWorkflowSubmittedStatus = "task submitted"
 const PgtaskWorkflowCompletedStatus = "task completed"
@@ -56,15 +57,16 @@ const PgtaskpgDumpBackup = "pgdumpbackup"
 const PgtaskpgDumpInfo = "pgdumpinfo"
 const PgtaskpgRestore = "pgrestore"
 
+const PgtaskBenchmark = "benchmark"
+
 // PgtaskSpec ...
 type PgtaskSpec struct {
-	Namespace   string        `json:"namespace"`
-	Name        string        `json:"name"`
-	StorageSpec PgStorageSpec `json:"storagespec"`
-	TaskType    string        `json:"tasktype"`
-	Status      string        `json:"status"`
-	//Parameters  string            `json:"parameters"`
-	Parameters map[string]string `json:"parameters"`
+	Namespace   string            `json:"namespace"`
+	Name        string            `json:"name"`
+	StorageSpec PgStorageSpec     `json:"storagespec"`
+	TaskType    string            `json:"tasktype"`
+	Status      string            `json:"status"`
+	Parameters  map[string]string `json:"parameters"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/vendor/github.com/crunchydata/postgres-operator/apiservermsgs/benchmarkmsgs.go
+++ b/vendor/github.com/crunchydata/postgres-operator/apiservermsgs/benchmarkmsgs.go
@@ -1,0 +1,86 @@
+package apiservermsgs
+
+import "errors"
+
+/*
+Copyright 2019 Crunchy Data Solutions, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// CreateBenchmarkResponse ...
+type CreateBenchmarkResponse struct {
+	Results []string
+	Status
+}
+
+// CreateBenchmarkRequest ...
+type CreateBenchmarkRequest struct {
+	Args          []string
+	BenchmarkOpts string
+	Clients       int
+	ClusterName   string
+	Database      string
+	InitOpts      string
+	Jobs          int
+	Namespace     string
+	Policy        string
+	Scale         int
+	Selector      string
+	Transactions  int
+	User          string
+}
+
+type DeleteBenchmarkRequest struct {
+	Args        []string
+	Namespace   string
+	ClusterName string
+	Selector    string
+}
+
+type ShowBenchmarkRequest struct {
+	Args        []string
+	Namespace   string
+	ClusterName string
+	Selector    string
+}
+
+type DeleteBenchmarkResponse struct {
+	Results []string
+	Status
+}
+
+type ShowBenchmarkResponse struct {
+	Results []string
+	Status
+}
+
+func (c CreateBenchmarkRequest) Validate() error {
+	if c.ClusterName == "" && c.Selector == "" {
+		return errors.New("cluster name or selector not set")
+	}
+	return nil
+}
+
+func (s ShowBenchmarkRequest) Validate() error {
+	if s.ClusterName == "" && s.Selector == "" {
+		return errors.New("cluster name or selector not set")
+	}
+	return nil
+}
+
+func (d DeleteBenchmarkRequest) Validate() error {
+	if d.ClusterName == "" && d.Selector == "" {
+		return errors.New("cluster name or selector not set")
+	}
+	return nil
+}

--- a/vendor/github.com/crunchydata/postgres-operator/apiservermsgs/clustermsgs.go
+++ b/vendor/github.com/crunchydata/postgres-operator/apiservermsgs/clustermsgs.go
@@ -45,6 +45,8 @@ type CreateClusterRequest struct {
 	PgbouncerFlag        bool
 	PgpoolSecret         string
 	PgbouncerSecret      string
+	PgbouncerPass        string
+	PgbouncerUser        string
 	CustomConfig         string
 	StorageConfig        string
 	ReplicaStorageConfig string

--- a/vendor/github.com/crunchydata/postgres-operator/apiservermsgs/common.go
+++ b/vendor/github.com/crunchydata/postgres-operator/apiservermsgs/common.go
@@ -17,7 +17,7 @@ limitations under the License.
 
 import ()
 
-const PGO_VERSION = "3.5.1"
+const PGO_VERSION = "3.5.2"
 
 // Ok status
 const Ok = "ok"

--- a/vendor/github.com/crunchydata/postgres-operator/apiservermsgs/pgbouncermsgs.go
+++ b/vendor/github.com/crunchydata/postgres-operator/apiservermsgs/pgbouncermsgs.go
@@ -22,6 +22,8 @@ type CreatePgbouncerRequest struct {
 	Args          []string
 	Selector      string
 	Namespace     string
+	PgbouncerUser string
+	PgbouncerPass string
 	ClientVersion string
 }
 

--- a/vendor/github.com/crunchydata/postgres-operator/config/pgoconfig.go
+++ b/vendor/github.com/crunchydata/postgres-operator/config/pgoconfig.go
@@ -17,7 +17,7 @@ limitations under the License.
 
 import (
 	"errors"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	crv1 "github.com/crunchydata/postgres-operator/apis/cr/v1"
 	"gopkg.in/yaml.v2"
 	"io/ioutil"

--- a/vendor/github.com/crunchydata/postgres-operator/kubeapi/configmap.go
+++ b/vendor/github.com/crunchydata/postgres-operator/kubeapi/configmap.go
@@ -1,7 +1,7 @@
 package kubeapi
 
 /*
- Copyright 2017-2019 Crunchy Data Solutions, Inc.
+ Copyright 2019 Crunchy Data Solutions, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
@@ -16,7 +16,7 @@ package kubeapi
 */
 
 import (
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -73,7 +73,6 @@ func ListConfigMap(clientset *kubernetes.Clientset, label, namespace string) (*v
 
 // DeleteConfigMap deletes a ConfigMap by name
 func DeleteConfigMap(clientset *kubernetes.Clientset, name, namespace string) error {
-
 	err := clientset.CoreV1().ConfigMaps(namespace).Delete(name, &meta_v1.DeleteOptions{})
 	if err != nil {
 		log.Error("error deleting ConfigMap " + err.Error())

--- a/vendor/github.com/crunchydata/postgres-operator/kubeapi/deployment.go
+++ b/vendor/github.com/crunchydata/postgres-operator/kubeapi/deployment.go
@@ -17,7 +17,7 @@ package kubeapi
 
 import (
 	"encoding/json"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	jsonpatch "github.com/evanphx/json-patch"
 	"k8s.io/api/apps/v1"
 	"k8s.io/api/extensions/v1beta1"

--- a/vendor/github.com/crunchydata/postgres-operator/kubeapi/exec.go
+++ b/vendor/github.com/crunchydata/postgres-operator/kubeapi/exec.go
@@ -19,7 +19,7 @@ import (
 	"bytes"
 	"io"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"

--- a/vendor/github.com/crunchydata/postgres-operator/kubeapi/job.go
+++ b/vendor/github.com/crunchydata/postgres-operator/kubeapi/job.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	v1batch "k8s.io/api/batch/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/vendor/github.com/crunchydata/postgres-operator/kubeapi/node.go
+++ b/vendor/github.com/crunchydata/postgres-operator/kubeapi/node.go
@@ -16,7 +16,7 @@ package kubeapi
 */
 
 import (
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"

--- a/vendor/github.com/crunchydata/postgres-operator/kubeapi/pgbackup.go
+++ b/vendor/github.com/crunchydata/postgres-operator/kubeapi/pgbackup.go
@@ -16,7 +16,7 @@ package kubeapi
 */
 
 import (
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	crv1 "github.com/crunchydata/postgres-operator/apis/cr/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/rest"

--- a/vendor/github.com/crunchydata/postgres-operator/kubeapi/pgcluster.go
+++ b/vendor/github.com/crunchydata/postgres-operator/kubeapi/pgcluster.go
@@ -16,7 +16,7 @@ package kubeapi
 */
 
 import (
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	crv1 "github.com/crunchydata/postgres-operator/apis/cr/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"

--- a/vendor/github.com/crunchydata/postgres-operator/kubeapi/pgpolicy.go
+++ b/vendor/github.com/crunchydata/postgres-operator/kubeapi/pgpolicy.go
@@ -16,7 +16,7 @@ package kubeapi
 */
 
 import (
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	crv1 "github.com/crunchydata/postgres-operator/apis/cr/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/rest"

--- a/vendor/github.com/crunchydata/postgres-operator/kubeapi/pgreplica.go
+++ b/vendor/github.com/crunchydata/postgres-operator/kubeapi/pgreplica.go
@@ -16,7 +16,7 @@ package kubeapi
 */
 
 import (
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	crv1 "github.com/crunchydata/postgres-operator/apis/cr/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"

--- a/vendor/github.com/crunchydata/postgres-operator/kubeapi/pgtask.go
+++ b/vendor/github.com/crunchydata/postgres-operator/kubeapi/pgtask.go
@@ -16,8 +16,8 @@ package kubeapi
 */
 
 import (
-	log "github.com/Sirupsen/logrus"
 	crv1 "github.com/crunchydata/postgres-operator/apis/cr/v1"
+	log "github.com/sirupsen/logrus"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/rest"

--- a/vendor/github.com/crunchydata/postgres-operator/kubeapi/pgupgrade.go
+++ b/vendor/github.com/crunchydata/postgres-operator/kubeapi/pgupgrade.go
@@ -17,7 +17,7 @@ package kubeapi
 
 import (
 	"encoding/json"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	crv1 "github.com/crunchydata/postgres-operator/apis/cr/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"

--- a/vendor/github.com/crunchydata/postgres-operator/kubeapi/pvc.go
+++ b/vendor/github.com/crunchydata/postgres-operator/kubeapi/pvc.go
@@ -16,7 +16,7 @@ package kubeapi
 */
 
 import (
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/vendor/github.com/crunchydata/postgres-operator/kubeapi/secret.go
+++ b/vendor/github.com/crunchydata/postgres-operator/kubeapi/secret.go
@@ -16,7 +16,7 @@ package kubeapi
 */
 
 import (
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/vendor/github.com/crunchydata/postgres-operator/kubeapi/service.go
+++ b/vendor/github.com/crunchydata/postgres-operator/kubeapi/service.go
@@ -16,7 +16,7 @@ package kubeapi
 */
 
 import (
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/vendor/github.com/crunchydata/postgres-operator/pgo/api/backrest.go
+++ b/vendor/github.com/crunchydata/postgres-operator/pgo/api/backrest.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"net/http"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	msgs "github.com/crunchydata/postgres-operator/apiservermsgs"
 )
 

--- a/vendor/github.com/crunchydata/postgres-operator/pgo/api/backup.go
+++ b/vendor/github.com/crunchydata/postgres-operator/pgo/api/backup.go
@@ -19,7 +19,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	msgs "github.com/crunchydata/postgres-operator/apiservermsgs"
 	"github.com/crunchydata/postgres-operator/util"
 	"net/http"

--- a/vendor/github.com/crunchydata/postgres-operator/pgo/api/cluster.go
+++ b/vendor/github.com/crunchydata/postgres-operator/pgo/api/cluster.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"net/http"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	msgs "github.com/crunchydata/postgres-operator/apiservermsgs"
 )
 

--- a/vendor/github.com/crunchydata/postgres-operator/pgo/api/common.go
+++ b/vendor/github.com/crunchydata/postgres-operator/pgo/api/common.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"net/http"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 // StatusCheck ...

--- a/vendor/github.com/crunchydata/postgres-operator/pgo/api/config.go
+++ b/vendor/github.com/crunchydata/postgres-operator/pgo/api/config.go
@@ -18,7 +18,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	msgs "github.com/crunchydata/postgres-operator/apiservermsgs"
 	"net/http"
 )

--- a/vendor/github.com/crunchydata/postgres-operator/pgo/api/df.go
+++ b/vendor/github.com/crunchydata/postgres-operator/pgo/api/df.go
@@ -18,7 +18,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	msgs "github.com/crunchydata/postgres-operator/apiservermsgs"
 	"net/http"
 )

--- a/vendor/github.com/crunchydata/postgres-operator/pgo/api/failover.go
+++ b/vendor/github.com/crunchydata/postgres-operator/pgo/api/failover.go
@@ -19,7 +19,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	msgs "github.com/crunchydata/postgres-operator/apiservermsgs"
 	"net/http"
 )

--- a/vendor/github.com/crunchydata/postgres-operator/pgo/api/label.go
+++ b/vendor/github.com/crunchydata/postgres-operator/pgo/api/label.go
@@ -18,7 +18,7 @@ package api
 import (
 	"bytes"
 	"encoding/json"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	msgs "github.com/crunchydata/postgres-operator/apiservermsgs"
 	"net/http"
 )

--- a/vendor/github.com/crunchydata/postgres-operator/pgo/api/load.go
+++ b/vendor/github.com/crunchydata/postgres-operator/pgo/api/load.go
@@ -18,7 +18,7 @@ package api
 import (
 	"bytes"
 	"encoding/json"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	msgs "github.com/crunchydata/postgres-operator/apiservermsgs"
 	"net/http"
 )

--- a/vendor/github.com/crunchydata/postgres-operator/pgo/api/pgbouncer.go
+++ b/vendor/github.com/crunchydata/postgres-operator/pgo/api/pgbouncer.go
@@ -18,7 +18,7 @@ package api
 import (
 	"bytes"
 	"encoding/json"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	msgs "github.com/crunchydata/postgres-operator/apiservermsgs"
 	"net/http"
 )

--- a/vendor/github.com/crunchydata/postgres-operator/pgo/api/pgdump.go
+++ b/vendor/github.com/crunchydata/postgres-operator/pgo/api/pgdump.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"net/http"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	msgs "github.com/crunchydata/postgres-operator/apiservermsgs"
 )
 

--- a/vendor/github.com/crunchydata/postgres-operator/pgo/api/pgpool.go
+++ b/vendor/github.com/crunchydata/postgres-operator/pgo/api/pgpool.go
@@ -18,7 +18,7 @@ package api
 import (
 	"bytes"
 	"encoding/json"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	msgs "github.com/crunchydata/postgres-operator/apiservermsgs"
 	"net/http"
 )

--- a/vendor/github.com/crunchydata/postgres-operator/pgo/api/pvc.go
+++ b/vendor/github.com/crunchydata/postgres-operator/pgo/api/pvc.go
@@ -18,16 +18,16 @@ package api
 import (
 	"encoding/json"
 	"fmt"
-	log "github.com/Sirupsen/logrus"
 	msgs "github.com/crunchydata/postgres-operator/apiservermsgs"
+	log "github.com/sirupsen/logrus"
 	"net/http"
 )
 
-func ShowPVC(httpclient *http.Client, pvcName, pvcRoot string, SessionCredentials *msgs.BasicAuthCredentials, ns string) (msgs.ShowPVCResponse, error) {
+func ShowPVC(httpclient *http.Client, pvcName, pvcRoot string, SessionCredentials *msgs.BasicAuthCredentials, nodeLabel, ns string) (msgs.ShowPVCResponse, error) {
 
 	var response msgs.ShowPVCResponse
 
-	url := SessionCredentials.APIServerURL + "/pvc/" + pvcName + "?pvcroot=" + pvcRoot + "&version=" + msgs.PGO_VERSION + "&namespace=" + ns
+	url := SessionCredentials.APIServerURL + "/pvc/" + pvcName + "?pvcroot=" + pvcRoot + "&nodelabel=" + nodeLabel + "&version=" + msgs.PGO_VERSION + "&namespace=" + ns
 	log.Debugf("ShowPVC called...[%s]", url)
 
 	action := "GET"

--- a/vendor/github.com/crunchydata/postgres-operator/pgo/api/reload.go
+++ b/vendor/github.com/crunchydata/postgres-operator/pgo/api/reload.go
@@ -18,7 +18,7 @@ package api
 import (
 	"bytes"
 	"encoding/json"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	msgs "github.com/crunchydata/postgres-operator/apiservermsgs"
 	"net/http"
 )

--- a/vendor/github.com/crunchydata/postgres-operator/pgo/api/restore.go
+++ b/vendor/github.com/crunchydata/postgres-operator/pgo/api/restore.go
@@ -18,7 +18,7 @@ package api
 import (
 	"bytes"
 	"encoding/json"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	msgs "github.com/crunchydata/postgres-operator/apiservermsgs"
 	"net/http"
 )

--- a/vendor/github.com/crunchydata/postgres-operator/pgo/api/restoreDump.go
+++ b/vendor/github.com/crunchydata/postgres-operator/pgo/api/restoreDump.go
@@ -18,7 +18,7 @@ package api
 import (
 	"bytes"
 	"encoding/json"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	msgs "github.com/crunchydata/postgres-operator/apiservermsgs"
 	"net/http"
 )

--- a/vendor/github.com/crunchydata/postgres-operator/pgo/api/scale.go
+++ b/vendor/github.com/crunchydata/postgres-operator/pgo/api/scale.go
@@ -18,7 +18,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	msgs "github.com/crunchydata/postgres-operator/apiservermsgs"
 	"net/http"
 	"strconv"

--- a/vendor/github.com/crunchydata/postgres-operator/pgo/api/scaledown.go
+++ b/vendor/github.com/crunchydata/postgres-operator/pgo/api/scaledown.go
@@ -18,7 +18,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	msgs "github.com/crunchydata/postgres-operator/apiservermsgs"
 	"github.com/crunchydata/postgres-operator/util"
 	"net/http"

--- a/vendor/github.com/crunchydata/postgres-operator/pgo/api/schedule.go
+++ b/vendor/github.com/crunchydata/postgres-operator/pgo/api/schedule.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"net/http"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	msgs "github.com/crunchydata/postgres-operator/apiservermsgs"
 )
 

--- a/vendor/github.com/crunchydata/postgres-operator/pgo/api/status.go
+++ b/vendor/github.com/crunchydata/postgres-operator/pgo/api/status.go
@@ -18,7 +18,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	msgs "github.com/crunchydata/postgres-operator/apiservermsgs"
 	"net/http"
 )

--- a/vendor/github.com/crunchydata/postgres-operator/pgo/api/test.go
+++ b/vendor/github.com/crunchydata/postgres-operator/pgo/api/test.go
@@ -18,7 +18,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	msgs "github.com/crunchydata/postgres-operator/apiservermsgs"
 	"net/http"
 )

--- a/vendor/github.com/crunchydata/postgres-operator/pgo/api/upgrade.go
+++ b/vendor/github.com/crunchydata/postgres-operator/pgo/api/upgrade.go
@@ -19,7 +19,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	msgs "github.com/crunchydata/postgres-operator/apiservermsgs"
 	"net/http"
 )

--- a/vendor/github.com/crunchydata/postgres-operator/pgo/api/user.go
+++ b/vendor/github.com/crunchydata/postgres-operator/pgo/api/user.go
@@ -19,7 +19,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	msgs "github.com/crunchydata/postgres-operator/apiservermsgs"
 	"net/http"
 )

--- a/vendor/github.com/crunchydata/postgres-operator/pgo/api/version.go
+++ b/vendor/github.com/crunchydata/postgres-operator/pgo/api/version.go
@@ -18,7 +18,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	msgs "github.com/crunchydata/postgres-operator/apiservermsgs"
 	"net/http"
 )

--- a/vendor/github.com/crunchydata/postgres-operator/pgo/api/workflow.go
+++ b/vendor/github.com/crunchydata/postgres-operator/pgo/api/workflow.go
@@ -18,7 +18,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	msgs "github.com/crunchydata/postgres-operator/apiservermsgs"
 	"net/http"
 )

--- a/vendor/github.com/crunchydata/postgres-operator/util/failover.go
+++ b/vendor/github.com/crunchydata/postgres-operator/util/failover.go
@@ -19,7 +19,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	crv1 "github.com/crunchydata/postgres-operator/apis/cr/v1"
 	msgs "github.com/crunchydata/postgres-operator/apiservermsgs"
 	"github.com/crunchydata/postgres-operator/kubeapi"

--- a/vendor/github.com/crunchydata/postgres-operator/util/labels.go
+++ b/vendor/github.com/crunchydata/postgres-operator/util/labels.go
@@ -15,8 +15,6 @@ package util
  limitations under the License.
 */
 
-import ()
-
 // resource labels used by the operator
 const LABEL_NAME = "name"
 const LABEL_SELECTOR = "selector"
@@ -58,6 +56,7 @@ const LABEL_UPGRADE_DATE = "operator-upgrade-date"
 const LABEL_DELETE_DATA = "delete-data"
 
 const LABEL_BACKREST = "pgo-backrest"
+const LABEL_BACKREST_JOB = "pgo-backrest-job"
 const LABEL_BACKREST_RESTORE = "pgo-backrest-restore"
 const LABEL_CONTAINER_NAME = "containername"
 const LABEL_POD_NAME = "podname"
@@ -114,6 +113,8 @@ const LABEL_PGBOUNCER_TASK_ADD = "pgbouncer-add"
 const LABEL_PGBOUNCER_TASK_DELETE = "pgbouncer-delete"
 const LABEL_PGBOUNCER_TASK_CLUSTER = "pgbouncer-cluster"
 const LABEL_PGBOUNCER_TASK_RECONFIGURE = "pgbouncer-reconfigure"
+const LABEL_PGBOUNCER_USER = "pgbouncer-user"
+const LABEL_PGBOUNCER_PASS = "pgbouncer-password"
 
 const LABEL_JOB_NAME = "job-name"
 const LABEL_PGBACKREST_STANZA = "pgbackrest-stanza"
@@ -122,6 +123,8 @@ const LABEL_PGBACKREST_REPO_PATH = "pgbackrest-repo-path"
 const LABEL_PGBACKREST_REPO_HOST = "pgbackrest-repo-host"
 
 const LABEL_PGO_BACKREST_REPO = "pgo-backrest-repo"
+
+const LABEL_PGO_BENCHMARK = "pgo-benchmark"
 
 const LABEL_DEPLOYMENT_NAME = "deployment-name"
 const LABEL_SERVICE_NAME = "service-name"

--- a/vendor/github.com/crunchydata/postgres-operator/util/policy.go
+++ b/vendor/github.com/crunchydata/postgres-operator/util/policy.go
@@ -16,7 +16,7 @@ package util
 */
 
 import (
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	crv1 "github.com/crunchydata/postgres-operator/apis/cr/v1"
 	"github.com/crunchydata/postgres-operator/kubeapi"
 	"io/ioutil"

--- a/vendor/github.com/crunchydata/postgres-operator/util/secrets.go
+++ b/vendor/github.com/crunchydata/postgres-operator/util/secrets.go
@@ -16,7 +16,7 @@ package util
 */
 
 import (
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	//crv1 "github.com/crunchydata/postgres-operator/apis/cr/v1"
 	//msgs "github.com/crunchydata/postgres-operator/apiservermsgs"
 	"github.com/crunchydata/postgres-operator/kubeapi"

--- a/vendor/github.com/crunchydata/postgres-operator/util/util.go
+++ b/vendor/github.com/crunchydata/postgres-operator/util/util.go
@@ -22,7 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	crv1 "github.com/crunchydata/postgres-operator/apis/cr/v1"
 	"github.com/crunchydata/postgres-operator/kubeapi"
 	jsonpatch "github.com/evanphx/json-patch"

--- a/vendor/github.com/crunchydata/postgres-operator/util/waituntil.go
+++ b/vendor/github.com/crunchydata/postgres-operator/util/waituntil.go
@@ -16,7 +16,7 @@ package util
 */
 
 import (
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"


### PR DESCRIPTION
Updated the postgres-operator dependency to v3.5.2 and updated the pgo-osb version number to v1.2.3 (includes updating the compatibility list in the readme doc).

Also fixed a case-sensitivity issue with the **logrus** logging package (see section **Seeing weird case-sensitive problems?** at the following URL for more details: https://github.com/sirupsen/logrus/blob/master/README.md)

[ch3008]