### PR TITLE
 Updated "postgres-operator" Dependency (3.5.3) & PGO-OSB Version Number (1.2.4) 

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,7 +26,7 @@
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
-  digest = "1:4c55656d7655f726e1622184fe53cf7e70e08cba1d314b83d59f627f40490565"
+  digest = "1:9187af3aff11828930bb5b3d8005f34e367bf658c6187eae8f8403cb9bcff0f5"
   name = "github.com/crunchydata/postgres-operator"
   packages = [
     "apis/cr/v1",
@@ -37,8 +37,8 @@
     "util",
   ]
   pruneopts = "NUT"
-  revision = "7e867ebf211b488def26dfaf10d7b2b5bbd6f5f6"
-  version = "3.5.2"
+  revision = "ee09d3a2b6730f724b907fe328a6cc96de223eff"
+  version = "3.5.3"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -47,7 +47,7 @@
 
 [[constraint]]
   name = "github.com/crunchydata/postgres-operator"
-  version = "3.5.2"
+  version = "3.5.3"
 
 [[override]]
   name = "github.com/spf13/cobra"

--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 image::crunchy_logo.png[Crunchy Data Logo]
 
-Latest Release: v1.2.3, {docdate}
+Latest Release: v1.2.4, {docdate}
 
 == General
 
@@ -30,6 +30,7 @@ See the following:
 
 == Compatibility
 
+ * pgo-osb 1.2.4 works with Postgres Operator 3.5.3
  * pgo-osb 1.2.3 works with Postgres Operator 3.5.2
  * pgo-osb 1.2.2 works with Postgres Operator 3.5.1
  * pgo-osb 1.2.1 works with Postgres Operator 3.5.0
@@ -64,7 +65,7 @@ export OSB_NAMESPACE=demo
 export OSB_CMD=kubectl
 export OSB_ROOT=$GOPATH/src/github.com/crunchydata/pgo-osb
 export OSB_BASEOS=centos7
-export OSB_VERSION=1.2.3
+export OSB_VERSION=1.2.4
 export OSB_IMAGE_TAG=$OSB_BASEOS-$OSB_VERSION
 export OSB_IMAGE_PREFIX=crunchydata
 ....

--- a/centos7/Dockerfile.pgo-osb.centos7
+++ b/centos7/Dockerfile.pgo-osb.centos7
@@ -1,8 +1,8 @@
 FROM centos:7
 
 LABEL Vendor="Crunchy Data Solutions" \
-        Version="1.2.3" \
-        Release="1.2.3" \
+        Version="1.2.4" \
+        Release="1.2.4" \
         summary="Crunchy Data pgo-osb open service broker " \
         description="Crunchy Data PostgreSQL Operator - pgo-osb "
 

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -38,7 +38,7 @@ spec:
         - --CO_APISERVER_URL
         - "https://postgres-operator:8443"
         - --CO_APISERVER_VERSION
-        - "3.5.2"
+        - "3.5.3"
         - --insecure
         - "true"
         - --logtostderr

--- a/vendor/github.com/crunchydata/postgres-operator/apiservermsgs/common.go
+++ b/vendor/github.com/crunchydata/postgres-operator/apiservermsgs/common.go
@@ -17,7 +17,7 @@ limitations under the License.
 
 import ()
 
-const PGO_VERSION = "3.5.2"
+const PGO_VERSION = "3.5.3"
 
 // Ok status
 const Ok = "ok"


### PR DESCRIPTION
Updated the **postgres-operator** dependency to **v3.5.3** and updated the **pgo-osb** version number to **v1.2.4** (includes updating the compatibility list in the readme doc).

[ch4092]