### PR TITLE
 Updated pgo-osb for Compatibility with PGO v4.0.1

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,7 +26,7 @@
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
-  digest = "1:5ff116f241c184098cef2c6b09649534dc7cf21ca6e155898b931eac19040320"
+  digest = "1:cb1e1b9b3291908003f819e6e788c37fded1078eb278919d42e022f1f5ec86bc"
   name = "github.com/crunchydata/postgres-operator"
   packages = [
     "apis/cr/v1",
@@ -37,8 +37,8 @@
     "util",
   ]
   pruneopts = "NUT"
-  revision = "7fb5f61381314e0f7886709a6ffb27c027571050"
-  version = "4.0.0"
+  revision = "f2ad92f8dccfa363801d5630b29b591371fb69e8"
+  version = "4.0.1"
 
 [[projects]]
   branch = "master"
@@ -632,7 +632,10 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/crunchydata/postgres-operator/apis/cr/v1",
     "github.com/crunchydata/postgres-operator/apiservermsgs",
+    "github.com/crunchydata/postgres-operator/config",
+    "github.com/crunchydata/postgres-operator/kubeapi",
     "github.com/crunchydata/postgres-operator/pgo/api",
     "github.com/crunchydata/postgres-operator/util",
     "github.com/pmorie/go-open-service-broker-client/v2",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -47,7 +47,7 @@
 
 [[constraint]]
   name = "github.com/crunchydata/postgres-operator"
-  version = "4.0.0"
+  version = "4.0.1"
 
 [[override]]
   name = "github.com/spf13/cobra"

--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 image::crunchy_logo.png[Crunchy Data Logo]
 
-Latest Release: v1.3.0, {docdate}
+Latest Release: v4.0.1, {docdate}
 
 == General
 
@@ -30,14 +30,20 @@ See the following:
 
 == Compatibility
 
- * pgo-osb 1.3.0 works with Postgres Operator 4.0.0
+Starting with *pgo-osb* version 4.0.0, the release schedule and version number for *pgo-osb* will be aligned with the release
+schedule and version number for the the 
+link:https://access.crunchydata.com/documentation/postgres-operator/latest[Crunchy PostgreSQL Operator].  Therefore, to ensure
+compatibility between *pgo-osb* and the PostreSQL Operator, please ensure the version number for *pgo-osb* matches the
+version number of the PostreSQL Operator deployed in your environment.  For instance, if you are using *pgo-osb* v4.0.1, please
+ensure the Crunchy PostreSQL Operator v4.0.1 is also deployed in your environment.
 
 == Prerequisites
 
 golang 1.9 or above is required to build this project.
 
 Running the *pgo-osb* service broker assumes you have successfully deployed
-the PostgreSQL Operator.  See https://github.com/CrunchyData/postgres-operator for documentation on deploying the PostgreSQL Operator.
+the PostgreSQL Operator.  See https://access.crunchydata.com/documentation/postgres-operator/latest for documentation on 
+deploying the PostgreSQL Operator.
 
 Please note that if *pgo-osb* is deployed to a different namespace than the PostgreSQL Operator, DNS must be utilized when specifying 
 the URL for the PostgreSQL Operator API server.  This is done using environment variable `PGO_APISERVER_URL` in the *pgo-osb* 
@@ -94,7 +100,7 @@ export OSB_NAMESPACE=demo
 export OSB_CMD=kubectl
 export OSB_ROOT=$GOPATH/src/github.com/crunchydata/pgo-osb
 export OSB_BASEOS=centos7
-export OSB_VERSION=1.3.0
+export OSB_VERSION=4.0.1
 export OSB_IMAGE_TAG=$OSB_BASEOS-$OSB_VERSION
 export OSB_IMAGE_PREFIX=crunchydata
 ....
@@ -122,9 +128,6 @@ https://svc-cat.io/docs/install/
 Instructions on that link are provided to also install the
 very useful *svcat* utility for inspecting and working
 with the service catalog.
-
-WARNING:  we have found issues using Helm 2.10 when installing Service Catalog, we tend
-to use Helm 2.9.1.
 
 == Deploy
 
@@ -180,8 +183,10 @@ kubectl get servicebinding
 
 You can view the binding and the generated Postgres credentials
 using this command:
+[source]
 ....
-$ svcat describe binding testinstance-binding
+# show the binding without secrets
+$ svcat describe binding testinstance-binding -n $OSB_NAMESPACE
   Name:        testinstance-binding
   Namespace:   demo
   Status:      Ready - Injected bind result @ 2018-08-24 13:44:29 +0000 UTC
@@ -194,7 +199,9 @@ Parameters:
 Secret Data:
   secrets    111 bytes
   services   151 bytes
-[osb@kube11 pgo-osb]$ svcat describe binding testinstance-binding --show-secrets
+
+# show the binding with secrets
+$ svcat describe binding testinstance-binding --show-secrets -n $OSB_NAMESPACE
   Name:        testinstance-binding
   Namespace:   demo
   Status:      Ready - Injected bind result @ 2018-08-24 13:44:29 +0000 UTC
@@ -250,7 +257,7 @@ Broker:        pgo-osb
 
 === View Instances in a Namespace
 ....
-$ svcat get instances -n demo
+$ svcat get instances -n $OSB_NAMESPACE
 NAME      NAMESPACE        CLASS         PLAN     STATUS
 +------------+-----------+-----------------+---------+--------+
   testinstance   demo        pgo-osb-service   default   Ready
@@ -262,11 +269,12 @@ NAME      NAMESPACE        CLASS         PLAN     STATUS
 
 You can remove the bindings and instances using these commands:
 ....
-$ svcat unbind testinstance
+$ svcat unbind testinstance -n $OSB_NAMESPACE
 deleted testinstance-binding
-$ svcat unbind testinstance2
+$ svcat unbind testinstance2 -n $OSB_NAMESPACE
 deleted testinstance2-binding
-$ svcat deprovision testinstance
+$ svcat deprovision testinstance -n $OSB_NAMESPACE
 deleted testinstance
-$ svcat deprovision testinstance2
+$ svcat deprovision testinstance2 -n $OSB_NAMESPACE
+deleted testinstance2
 ....

--- a/centos7/Dockerfile.pgo-osb.centos7
+++ b/centos7/Dockerfile.pgo-osb.centos7
@@ -1,8 +1,8 @@
 FROM centos:7
 
 LABEL Vendor="Crunchy Data Solutions" \
-        Version="1.3.0" \
-        Release="1.3.0" \
+        Version="4.0.1" \
+        Release="4.0.1" \
         summary="Crunchy Data pgo-osb open service broker " \
         description="Crunchy Data PostgreSQL Operator - pgo-osb "
 

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -38,7 +38,7 @@ spec:
         - --PGO_APISERVER_URL
         - "https://postgres-operator:8443"
         - --PGO_APISERVER_VERSION
-        - "4.0.0"
+        - "4.0.1"
         - --insecure
         - "true"
         - --logtostderr

--- a/vendor/github.com/crunchydata/postgres-operator/apiservermsgs/clustermsgs.go
+++ b/vendor/github.com/crunchydata/postgres-operator/apiservermsgs/clustermsgs.go
@@ -47,7 +47,7 @@ type CreateClusterRequest struct {
 	BadgerFlag          bool
 	AutofailFlag        bool
 	ArchiveFlag         bool
-	BackrestFlag        bool
+	BackrestFlag        string
 	BackrestStorageType string
 	//BackrestRestoreFrom  string
 	PgpoolFlag           bool

--- a/vendor/github.com/crunchydata/postgres-operator/apiservermsgs/common.go
+++ b/vendor/github.com/crunchydata/postgres-operator/apiservermsgs/common.go
@@ -17,7 +17,7 @@ limitations under the License.
 
 import ()
 
-const PGO_VERSION = "4.0.0"
+const PGO_VERSION = "4.0.1"
 
 // Ok status
 const Ok = "ok"

--- a/vendor/github.com/crunchydata/postgres-operator/kubeapi/pgcluster.go
+++ b/vendor/github.com/crunchydata/postgres-operator/kubeapi/pgcluster.go
@@ -16,8 +16,8 @@ package kubeapi
 */
 
 import (
-	crv1 "github.com/crunchydata/postgres-operator/apis/cr/v1"
 	log "github.com/sirupsen/logrus"
+	crv1 "github.com/crunchydata/postgres-operator/apis/cr/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/rest"


### PR DESCRIPTION
Updated pgo-osb for compatibility with PostgreSQL Operator v4.0.1.  Also includes documentation cleanup and updates for the new pgo-osb versioning scheme.

[ch4452]