### PR TITLE
Add `PGO_CLUSTER_NAMESPACE` environmental variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,11 @@ pgo-osb-69c76578b9-v7s9k   1/1       Running   0          16m
 
 To use the **pgo-osb** broker, please follow the following instructions.
 
+Note that if you want to specify a specific namespace for where your PostgreSQL
+cluster is deployed to, you can use the `PGO_CLUSTER_NAMESPACE` environmental
+variable. Otherwise, **pgo-osb** will search across all namespaces to look up
+where the cluster exists.
+
 ### Show Available Plans
 
 ```shell

--- a/pkg/broker/pgo.go
+++ b/pkg/broker/pgo.go
@@ -89,6 +89,12 @@ func (po *PGOperator) findInstanceNamespace(instID string) (string, error) {
 	if ns, ok := po.nsLookup[instID]; ok {
 		po.nsMutex.RUnlock()
 		return ns, nil
+	} else if ns := os.Getenv("PGO_CLUSTER_NAMESPACE"); ns != "" {
+		po.nsMutex.RUnlock()
+		po.nsMutex.Lock()
+		po.nsLookup[instID] = ns
+		po.nsMutex.Unlock()
+		return ns, nil
 	} else {
 		po.nsMutex.RUnlock()
 		selector := po.instLabel(instID)


### PR DESCRIPTION
This allows for one to specify the specific namespace that a
PostgreSQL cluster is deployed into without having to perform the
lookup across all namespaces.