### PR TITLE
Set database name to that of cluster name during bind

### DIFF
--- a/pkg/osb-bridge/logic.go
+++ b/pkg/osb-bridge/logic.go
@@ -295,7 +295,7 @@ func (b *BusinessLogic) Bind(request *osb.BindRequest, c *osblib.RequestContext)
 	}
 
 	port := 5432
-	dbName := "userdb"
+	dbName := clusterDetail.ClusterName
 	host := clusterDetail.ExternalIP
 	if host == "" {
 		host = clusterDetail.ClusterIP


### PR DESCRIPTION
This behavior changed in Postgres Operator 4.3, so the OSB
should match this.