### PR TITLE
Make default plan equivalent to "standalone small"

### DIFF
--- a/pkg/broker/pgo.go
+++ b/pkg/broker/pgo.go
@@ -183,6 +183,8 @@ func (po *PGOperator) instLabel(instID string) string {
 // unique identifiers
 func (po *PGOperator) createRequestByPlan(planID string, req *msgs.CreateClusterRequest) {
 	switch planID {
+	default:
+		fallthrough
 	case "885a1cb6-ca42-43e9-a725-8195918e1343":
 		req.MetricsFlag = true
 		req.CPULimit = "1.0"
@@ -228,8 +230,6 @@ func (po *PGOperator) createRequestByPlan(planID string, req *msgs.CreateCluster
 		req.MemoryLimit = "2Gi"
 		req.MemoryRequest = "2Gi"
 		req.StorageConfig = "osblarge"
-	default:
-		return
 	}
 }
 


### PR DESCRIPTION
Many Kubernetes environments require for explicit settings of
resources in deployed Pods, so our default plan should effectively
be the equivalent of a small plan.