### PR TITLE
Determine name of default database in bind request

### DIFF
--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -15,8 +15,6 @@ package broker
  limitations under the License.
 */
 
-import ()
-
 // BasicCred represents a common pair of username and password
 type BasicCred struct {
 	Username string
@@ -29,6 +27,7 @@ type ClusterDetails struct {
 	ClusterIP   string
 	ExternalIP  string
 	ClusterName string
+	Database    string
 }
 
 type CreateRequest struct {

--- a/pkg/broker/pgo.go
+++ b/pkg/broker/pgo.go
@@ -370,6 +370,7 @@ func (po *PGOperator) ClusterDetail(instanceID string) (ClusterDetails, error) {
 		ClusterIP:   svc.ClusterIP,
 		ClusterName: svc.ClusterName,
 		ExternalIP:  svc.ExternalIP,
+		Database:    detail.Cluster.Spec.Database,
 	}
 
 	return cDetail, nil

--- a/pkg/osb-bridge/logic.go
+++ b/pkg/osb-bridge/logic.go
@@ -296,7 +296,7 @@ func (b *BusinessLogic) Bind(request *osb.BindRequest, c *osblib.RequestContext)
 	}
 
 	port := 5432
-	dbName := clusterDetail.ClusterName
+	dbName := clusterDetail.Database
 	host := clusterDetail.ExternalIP
 	if host == "" {
 		host = clusterDetail.ClusterIP


### PR DESCRIPTION
The name of the default database is available in the Postgres
Operator custom resource. This can be used to allow for the broker
to automatically bind to the PostgreSQL database created by the
Postgres Operator.